### PR TITLE
Add language metadata to four-track MKV muxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ python UsmDiviner.py input.usm --mux-mkv --ffmpeg "D:/tools/ffmpeg/bin/ffmpeg.ex
 | `--keep-intermediate-audio` | 音频解码成功后保留 `.hca/.adx` 和 `.hcakey` 文件 |
 | `--no-adx-audiomask` | 不对 ADX 应用 AudioMask，默认结果为杂音时可尝试使用 |
 | `--mux-mkv` | 使用 ffmpeg 封装为 MKV |
+| `--audio-language-preset <gamename>` | MKV 音轨语言 metadata 预设，默认为 `none`；会根据指定游戏的音轨约定映射 language metadata，当前支持 `gi`；需要配合 `--mux-mkv` 使用 |
 | `--ffmpeg PATH` | 手动指定 ffmpeg 路径 |
 
 ## 输出

--- a/usmdiviner/cli.py
+++ b/usmdiviner/cli.py
@@ -61,6 +61,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="mux decrypted video and usable audio into MKV",
     )
     parser.add_argument(
+        "--audio-language-preset",
+        choices=("none", "gi"),
+        metavar="<gamename>",
+        default="none",
+        help=(
+            "audio language metadata preset for MKV muxing; "
+            "requires --mux-mkv and maps tracks by game convention"
+        ),
+    )
+    parser.add_argument(
         "--ffmpeg",
         default=None,
         help="path to ffmpeg for --mux-mkv; auto-detected if omitted",
@@ -79,6 +89,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         parser.error("--extract-only cannot be used with --fast")
     if args.extract_only and args.mux_mkv:
         parser.error("--extract-only cannot be used with --mux-mkv")
+    if not args.mux_mkv and args.audio_language_preset != "none":
+        parser.error("--audio-language-preset requires --mux-mkv")
     return args
 
 
@@ -111,6 +123,7 @@ def main(argv: list[str] | None = None) -> int:
         fast=args.fast,
         manual_key=args.key,
         extract_only=args.extract_only,
+        audio_language_preset=args.audio_language_preset,
     )
 
     Path(args.output).mkdir(parents=True, exist_ok=True)

--- a/usmdiviner/models.py
+++ b/usmdiviner/models.py
@@ -70,3 +70,4 @@ class ProcessOptions:
     fast: bool
     manual_key: int | None
     extract_only: bool
+    audio_language_preset: str

--- a/usmdiviner/processor.py
+++ b/usmdiviner/processor.py
@@ -33,6 +33,13 @@ from .usm import parse_usm_chunks
 
 logger = logging.getLogger(__name__)
 
+AUDIO_LANGUAGE_METADATA = {
+    0: ("chi", "中文"),
+    1: ("eng", "English"),
+    2: ("jpn", "日本語"),
+    3: ("kor", "한국어"),
+}
+
 
 def process_one(usm_path_str: str, opt: ProcessOptions) -> dict:
     usm_path = Path(usm_path_str)
@@ -369,12 +376,15 @@ def _maybe_mux(
         }, False
 
     mux_audio_inputs: list[Path] = []
+    mux_audio_metadata: list[tuple[str, str] | None] = []
     for ch, audio_path in sorted(audio_paths.items()):
         dec = decoded.get(ch) or {}
         if dec.get("ok") and dec.get("wav"):
             mux_audio_inputs.append(Path(dec["wav"]))
+            mux_audio_metadata.append(AUDIO_LANGUAGE_METADATA.get(ch))
         elif audio_decisions[ch].format == "adx":
             mux_audio_inputs.append(audio_path)
+            mux_audio_metadata.append(AUDIO_LANGUAGE_METADATA.get(ch))
 
     ffmpeg = find_ffmpeg(opt.ffmpeg)
     if not ffmpeg:
@@ -382,7 +392,13 @@ def _maybe_mux(
 
     mkv_path = out_dir / f"{base}.mkv"
     try:
-        ok, log = mux_to_mkv(ffmpeg, video_path, mux_audio_inputs, mkv_path)
+        ok, log = mux_to_mkv(
+            ffmpeg,
+            video_path,
+            mux_audio_inputs,
+            mkv_path,
+            audio_metadata=mux_audio_metadata,
+        )
     except ExternalToolError as exc:
         logger.warning("mkv mux failed for %s: %s", base, exc)
         message = "ffmpeg mux failed; extracted streams were kept"

--- a/usmdiviner/processor.py
+++ b/usmdiviner/processor.py
@@ -33,11 +33,15 @@ from .usm import parse_usm_chunks
 
 logger = logging.getLogger(__name__)
 
-AUDIO_LANGUAGE_METADATA = {
-    0: ("chi", "中文"),
-    1: ("eng", "English"),
-    2: ("jpn", "日本語"),
-    3: ("kor", "한국어"),
+AudioLanguageMapping = dict[int, str]
+
+AUDIO_LANGUAGE_PRESETS: dict[str, AudioLanguageMapping] = {
+    "gi": {
+        0: "chi",
+        1: "eng",
+        2: "jpn",
+        3: "kor",
+    },
 }
 
 
@@ -368,27 +372,41 @@ def _maybe_mux(
 ) -> tuple[dict | None, bool]:
     if not opt.mux_mkv:
         return None, False
-    if not video_path:
-        return {
-            "ok": False,
-            "mkv": None,
-            "log_tail": "video stream not found; MKV not created",
-        }, False
 
     mux_audio_inputs: list[Path] = []
-    mux_audio_metadata: list[tuple[str, str] | None] = []
+    mux_audio_channels: list[int] = []
     for ch, audio_path in sorted(audio_paths.items()):
         dec = decoded.get(ch) or {}
         if dec.get("ok") and dec.get("wav"):
             mux_audio_inputs.append(Path(dec["wav"]))
-            mux_audio_metadata.append(AUDIO_LANGUAGE_METADATA.get(ch))
+            mux_audio_channels.append(ch)
         elif audio_decisions[ch].format == "adx":
             mux_audio_inputs.append(audio_path)
-            mux_audio_metadata.append(AUDIO_LANGUAGE_METADATA.get(ch))
+            mux_audio_channels.append(ch)
+
+    mux_audio_languages, audio_metadata_report = _audio_languages_for_preset(
+        opt.audio_language_preset,
+        mux_audio_channels,
+    )
+
+    if not video_path:
+        report = {
+            "ok": False,
+            "mkv": None,
+            "log_tail": "video stream not found; MKV not created",
+        }
+        _maybe_add_audio_metadata_report(report, audio_metadata_report)
+        return report, False
 
     ffmpeg = find_ffmpeg(opt.ffmpeg)
     if not ffmpeg:
-        return {"ok": False, "mkv": None, "log_tail": "ffmpeg not found"}, False
+        report = {
+            "ok": False,
+            "mkv": None,
+            "log_tail": "ffmpeg not found",
+        }
+        _maybe_add_audio_metadata_report(report, audio_metadata_report)
+        return report, False
 
     mkv_path = out_dir / f"{base}.mkv"
     try:
@@ -397,31 +415,78 @@ def _maybe_mux(
             video_path,
             mux_audio_inputs,
             mkv_path,
-            audio_metadata=mux_audio_metadata,
+            audio_languages=mux_audio_languages,
         )
     except ExternalToolError as exc:
         logger.warning("mkv mux failed for %s: %s", base, exc)
         message = "ffmpeg mux failed; extracted streams were kept"
-        return {
+        report = {
             "ok": False,
             "mkv": None,
             "message": message,
             "log_tail": str(exc),
             "streams_kept": True,
-        }, False
+        }
+        _maybe_add_audio_metadata_report(report, audio_metadata_report)
+        return report, False
 
     if not ok:
         message = _mux_failure_message(video_path, log)
         logger.warning("mkv mux skipped for %s: %s", base, message)
-        return {
+        report = {
             "ok": False,
             "mkv": None,
             "message": message,
             "log_tail": log[-1000:],
             "streams_kept": True,
-        }, False
+        }
+        _maybe_add_audio_metadata_report(report, audio_metadata_report)
+        return report, False
 
-    return {"ok": True, "mkv": str(mkv_path), "log_tail": log[-1000:]}, True
+    audio_metadata_report["applied"] = bool(mux_audio_languages)
+    report = {
+        "ok": True,
+        "mkv": str(mkv_path),
+        "log_tail": log[-1000:],
+    }
+    _maybe_add_audio_metadata_report(report, audio_metadata_report)
+    return report, True
+
+
+def _maybe_add_audio_metadata_report(report: dict, metadata_report: dict) -> None:
+    if metadata_report.get("preset") != "none":
+        report["audio_language_metadata"] = metadata_report
+
+
+def _audio_languages_for_preset(
+    preset: str,
+    channels: list[int],
+) -> tuple[list[str | None] | None, dict]:
+    report = {
+        "preset": preset,
+        "channels": channels,
+        "matched": False,
+        "applied": False,
+    }
+    if preset == "none":
+        report["reason"] = "preset disabled"
+        return None, report
+
+    mapping = AUDIO_LANGUAGE_PRESETS.get(preset)
+    if not mapping:
+        report["reason"] = "unknown preset"
+        return None, report
+
+    expected_channels = sorted(mapping)
+    report["expected_channels"] = expected_channels
+    if channels != expected_channels:
+        report["reason"] = "audio channels do not match preset"
+        return None, report
+
+    languages = [mapping[ch] for ch in channels]
+    report["matched"] = True
+    report["languages"] = languages
+    return languages, report
 
 
 def _mux_failure_message(video_path: Path, log: str) -> str:

--- a/usmdiviner/tools.py
+++ b/usmdiviner/tools.py
@@ -106,17 +106,17 @@ def mux_to_mkv(
     output_mkv: Path,
     timeout: int = 300,
     *,
-    audio_metadata: list[tuple[str, str] | None] | None = None,
+    audio_languages: list[str | None] | None = None,
 ) -> tuple[bool, str]:
     if not video_path.exists() or video_path.stat().st_size == 0:
         return False, "video stream does not exist"
 
-    existing_audio: list[tuple[Path, tuple[str, str] | None]] = []
+    existing_audio: list[tuple[Path, str | None]] = []
     for i, path in enumerate(audio_inputs):
         if not path.exists() or path.stat().st_size == 0:
             continue
-        metadata = audio_metadata[i] if audio_metadata and i < len(audio_metadata) else None
-        existing_audio.append((path, metadata))
+        language = audio_languages[i] if audio_languages and i < len(audio_languages) else None
+        existing_audio.append((path, language))
 
     output_mkv.parent.mkdir(parents=True, exist_ok=True)
     _safe_unlink(output_mkv)
@@ -130,17 +130,13 @@ def mux_to_mkv(
     cmd.extend(["-c:v", "copy"])
     if existing_audio:
         cmd.extend(["-c:a", "flac"])
-    if len(existing_audio) == 4:
-        for i, (_, metadata) in enumerate(existing_audio):
-            if not metadata:
-                continue
-            lang, title = metadata
-            cmd.extend([
-                f"-metadata:s:a:{i}",
-                f"language={lang}",
-                f"-metadata:s:a:{i}",
-                f"title={title}",
-            ])
+    if audio_languages and len(existing_audio) == len(audio_languages):
+        for i, (_, language) in enumerate(existing_audio):
+            if language:
+                cmd.extend([
+                    f"-metadata:s:a:{i}",
+                    f"language={language}",
+                ])
     cmd.append(str(output_mkv))
 
     try:

--- a/usmdiviner/tools.py
+++ b/usmdiviner/tools.py
@@ -105,17 +105,24 @@ def mux_to_mkv(
     audio_inputs: list[Path],
     output_mkv: Path,
     timeout: int = 300,
+    *,
+    audio_metadata: list[tuple[str, str] | None] | None = None,
 ) -> tuple[bool, str]:
     if not video_path.exists() or video_path.stat().st_size == 0:
         return False, "video stream does not exist"
 
-    existing_audio = [p for p in audio_inputs if p.exists() and p.stat().st_size > 0]
+    existing_audio: list[tuple[Path, tuple[str, str] | None]] = []
+    for i, path in enumerate(audio_inputs):
+        if not path.exists() or path.stat().st_size == 0:
+            continue
+        metadata = audio_metadata[i] if audio_metadata and i < len(audio_metadata) else None
+        existing_audio.append((path, metadata))
 
     output_mkv.parent.mkdir(parents=True, exist_ok=True)
     _safe_unlink(output_mkv)
 
     cmd = [ffmpeg, "-y", "-hide_banner", "-loglevel", "error", "-i", str(video_path)]
-    for ap in existing_audio:
+    for ap, _ in existing_audio:
         cmd.extend(["-i", str(ap)])
     cmd.extend(["-map", "0:v:0"])
     for i in range(len(existing_audio)):
@@ -123,6 +130,17 @@ def mux_to_mkv(
     cmd.extend(["-c:v", "copy"])
     if existing_audio:
         cmd.extend(["-c:a", "flac"])
+    if len(existing_audio) == 4:
+        for i, (_, metadata) in enumerate(existing_audio):
+            if not metadata:
+                continue
+            lang, title = metadata
+            cmd.extend([
+                f"-metadata:s:a:{i}",
+                f"language={lang}",
+                f"-metadata:s:a:{i}",
+                f"title={title}",
+            ])
     cmd.append(str(output_mkv))
 
     try:


### PR DESCRIPTION
Attach language and title metadata to MKV audio streams when muxing the expected four language tracks. The processor now maps audio channels 0-3 to Chinese, English, Japanese, and Korean metadata if all four audio streams are present.